### PR TITLE
macrursors: Improve performance

### DIFF
--- a/macrursors.el
+++ b/macrursors.el
@@ -82,12 +82,24 @@ and re-enable them in `macrursors-postapply-command'."
 
 (define-minor-mode macrursors-mode
   "Minor mode for when macrursors in active."
-  :lighter "macrursors"
+  :lighter macrursors-mode-line
   :keymap
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd macrursors-apply-keys) #'macrursors-end)
     (define-key map (kbd "C-g") #'macrursors-early-quit)
     map))
+
+(defcustom macrursors-mode-line
+  '(" MAC:" (:eval (if macrursors--overlays
+                       (format (propertize "%d/%d" 'face 'font-lock-warning-face)
+                        (1+ (cl-count-if (lambda (p) (< p (point))) macrursors--overlays
+                             :key #'overlay-start))
+                        (1+ (length macrursors--overlays)))
+                     (propertize "1/1" 'face 'font-lock-warning-face))))
+  "Mode-line format for Macrursors."
+  :type 'string
+  :risky t
+  :group 'macrursors)
 
 (defun macrursors--inside-secondary-selection ()
   (and-let*

--- a/macrursors.el
+++ b/macrursors.el
@@ -155,10 +155,15 @@ If OVERLAYS in non-nil, return a list with the positions of OVERLAYS."
     (error "No region active")))
 
 (defun macrursors--mark-next-instance-of (string &optional end)
-  (let ((cursor-positions (macrursors--get-overlay-positions)))
-    (while (and (search-forward string end t 1)
+  (let ((cursor-positions (macrursors--get-overlay-positions))
+        (matched-p))
+    (while (and (setq matched-p
+                      (re-search-forward string end t 1))
                 (member (point) cursor-positions)))
-    (when (< (point) (or end (point-max)))
+    (if (or (not matched-p)
+            (> (point) (or end (point-max)))
+            (member (point) cursor-positions))
+        (message "No more matches.")
       (macrursors--add-overlay-at-point (point)))))
 
 ;;;###autoload
@@ -178,11 +183,16 @@ If OVERLAYS in non-nil, return a list with the positions of OVERLAYS."
     (error "No region active")))
 
 (defun macrursors--mark-previous-instance-of (string &optional end)
-  (let ((cursor-positions (macrursors--get-overlay-positions)))
-    (while (and (search-forward string end t -1)
-                (member (+ (point) (length string)) cursor-positions)))
-    (when (> (point) (or end (point-min)))
-      (macrursors--add-overlay-at-point (+ (point) (length string))))))
+  (let ((cursor-positions (macrursors--get-overlay-positions))
+        (matched))
+    (while (and (setq matched
+                      (re-search-forward string end t -1))
+                (member (match-end 0) cursor-positions)))
+    (if (or (not matched)
+            (<= (point) (or end (point-min)))
+            (member (match-end 0) cursor-positions))
+        (message "No more matches.")
+      (macrursors--add-overlay-at-point (match-end 0)))))
 
 ;;;###autoload
 (defun macrursors-mark-previous-instance-of ()


### PR DESCRIPTION
Hi @corytertel,

I had a chance to check this package out this weekend.  It's very neat!  Thanks for starting this.

There were some easy opportunities for optimization so I rewrote some of the code and did some benchmarking.  Here's a summary.

### Optimization
-   I rewrote recursive calls as simple loops: elisp doesn't have tail-call optimization so the stack will fill up. (Wish it did, the recursion is so much cleaner!)
    -   `macrursors--mark-all-instances-of`
    -   `macrursors--mark-next-instance-of`
    -   `macrursors--mark-previous-instance-of`

-   `macrursors--inside-secondary-selection` is an expensive function.  (Benchmark it in the 36k line `xdisp.c` in the Emacs source code to see this.)  We don't need to look at all the overlays in the buffer, which `secondary-selection-exist-p` does.  I fixed it by simplifying the criterion.

-   `macrursors--mark-all-instances-of`, `macrursors--mark-next-instance-of`, `macrursors--mark-previous-instance-of`: since we are searching for a string in the buffer, ~~we don't need `re-search-forward`, replace with the simpler and much faster `search-forward`.~~  On second thought I've kept the `re-search-forward` in as it makes it possible to match special constructs like symbols. 

-   Use `execute-kbd-macro` instead of `kmacro-call-macro`.  The latter is meant for interactive use and does a bunch of processing we don't need, like messaging and setting up a transient keymap.  The former is a the C function that actually runs macros.  Note that it's not a command.  If you want a command here `call-last-kbd-macro` will work, but it changes the value of the `last-command` and `this-command` variables, which I think we shouldn't do here.

You've created `macrursors--apply-command` specifically to run commands (as opposed to functions), so I'm guessing you have some plan for this function.  I changed it so we can run `execute-kbd-macro` but retained the ability to run commands.  This function is in the hot loop and can be made faster by not checking if `cmd` is a command.

### Use Idiomatic Elisp
-  `macrursors-mark-all-instances-of`, `macrursors-mark-next-instance-of`, `macrursors-mark-previous-instance-of`: Use `region-beginning`, `region-end` and `use-region-p` (where appropriate)

### Add a mode-line indicator
A simple indicator that replaces the "macrocursors" lighter showing the number of matches and the position of the real cursor among them. It's the `MAC: 3/4` string here:

![2023-02-06-185039_768x24_scrot](https://user-images.githubusercontent.com/8607532/217135780-d65084ae-3154-4dde-8e96-eb2fbddd6123.png)

### Benchmark results
Benchmark in large buffers:

-   Open a large-ish buffer, switch to fundamental mode
-   Create a cursor at the beginning of every line and type in the word &ldquo;test&rdquo;.

I also produced the same edit using `replace-regexp` and with Emacs' rectangle editing (`string-rectangle`). Here are the results:

A test file, 500 lines

<table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">


<colgroup>
<col  class="org-left" />

<col  class="org-right" />

<col  class="org-left" />
</colgroup>
<thead>
<tr>
<th scope="col" class="org-left">Method</th>
<th scope="col" class="org-right">Time (seconds)</th>
<th scope="col" class="org-left">Memory allocated</th>
</tr>
</thead>

<tbody>
<tr>
<td class="org-left"><code>string-rectangle</code></td>
<td class="org-right">0.0</td>
<td class="org-left">-</td>
</tr>


<tr>
<td class="org-left"><code>replace-regexp</code></td>
<td class="org-right">0.0</td>
<td class="org-left">-</td>
</tr>


<tr>
<td class="org-left">Before this PR</td>
<td class="org-right">0.4711</td>
<td class="org-left">5.380 MB</td>
</tr>


<tr>
<td class="org-left">With this PR</td>
<td class="org-right">0.3820</td>
<td class="org-left">4.812 MB</td>
</tr>
</tbody>
</table>

`window.c`, 8600 lines:

<table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">


<colgroup>
<col  class="org-left" />

<col  class="org-right" />

<col  class="org-left" />
</colgroup>
<thead>
<tr>
<th scope="col" class="org-left">Method</th>
<th scope="col" class="org-right">Time (seconds)</th>
<th scope="col" class="org-left">Memory allocated</th>
</tr>
</thead>

<tbody>
<tr>
<td class="org-left"><code>string-rectangle</code></td>
<td class="org-right">0.2</td>
<td class="org-left">-</td>
</tr>


<tr>
<td class="org-left"><code>replace-regexp</code></td>
<td class="org-right">0.2</td>
<td class="org-left">-</td>
</tr>


<tr>
<td class="org-left">Before this PR</td>
<td class="org-right">error</td>
<td class="org-left">-</td>
</tr>


<tr>
<td class="org-left">With this PR</td>
<td class="org-right">70.2</td>
<td class="org-left">200 MB</td>
</tr>
</tbody>
</table>

`xdisp.c`, 36000 lines:

<table border="2" cellspacing="0" cellpadding="6" rules="groups" frame="hsides">


<colgroup>
<col  class="org-left" />

<col  class="org-left" />
</colgroup>
<thead>
<tr>
<th scope="col" class="org-left">Method</th>
<th scope="col" class="org-left">Time (seconds)</th>
</tr>
</thead>

<tbody>
<tr>
<td class="org-left"><code>string-rectangle</code></td>
<td class="org-left">66.0</td>
</tr>


<tr>
<td class="org-left"><code>replace-regexp</code></td>
<td class="org-left">65.0</td>
</tr>


<tr>
<td class="org-left">Before this PR</td>
<td class="org-left">Emacs crashed</td>
</tr>


<tr>
<td class="org-left">With this PR</td>
<td class="org-left">Emacs froze indefinitely</td>
</tr>
</tbody>
</table>

With more care, a 2x-3x speedup is not infeasible.  I see some easy wins by disabling certain modes, handling the undo change groups better, using `overlay-recenter` etc.  At the very least I can get it to not lock up Emacs on the 36000 line file.

### Other concerns (not implemented)

-  `macrursors--mark-next-instance-of`, `macrursors--mark-previous-instance-of`: `macursors--get-overlay-positions` is called every time.  Can be addressed by storing the overlay start positions in a buffer local var.  `overlay-start` is fast enough, so this is a secondary concern for now.

- `macrursors--defun-mark-all`: This macro should probably just be a function.  I can rewrite it.

Let me know what you think!