### PR TITLE
macrursors: Change pre/postapply commands to hooks

### DIFF
--- a/README.org
+++ b/README.org
@@ -13,11 +13,9 @@ where ~n = # of cursors~ and ~m = # of actions~. A much needed improvement. This
 Macrursors also gives you the abilty to temporily turn off minor modes, change the setting of variables, and more while the edits are applying. Anything that is unneeded while applying edits (like auto-complete popups) is recommended to be temporarily turned off to further increase the speed.
 
 #+begin_src emacs-lisp
-;; The following code will turn off corfu only when the edits are being applied
-(setq macrursors-preapply-command
-  (lambda () (corfu-mode -1)))
-(setq macrursors-postapply-command
-  (lambda () (corfu-mode 1)))
+  ;; The following code will turn off corfu only when the edits are being applied
+  (add-hook 'macrursors-pre-finish-hook 'corfu-mode)
+  (add-hook 'macrursors-post-finish-hook 'corfu-mode)
 #+end_src
 
 ** Size
@@ -86,35 +84,27 @@ Macrursors is not yet on Melpa, so you will need to manually add ~macrursors.el~
 Example set up of macrursors.
 
 #+begin_src emacs-lisp
-(use-package macrursors
-  :custom
-  (macrursors-preapply-command
-   (lambda ()
-     (corfu-mode -1)
-     (goggles-mode -1)
-     (beacon-mode -1)))
-  (macrursors-postapply-command
-   (lambda ()
-     (corfu-mode 1)
-     (goggles-mode 1)
-     (beacon-mode 1)))
-  :config
-  (define-prefix-command 'macrursors-mark-map)
-  (global-set-key (kbd "M-SPC") #'macrursors-grab)
-  (global-set-key (kbd "C-c SPC") #'macrursors-swap-grab)
-  (global-set-key (kbd "C-c S-SPC") #'macrursors-sync-grab)
-  (global-set-key (kbd "C->") #'macrursors-mark-next-instance-of)
-  (global-set-key (kbd "C-<") #'macrursors-mark-previous-instance-of)
-  (global-set-key (kbd "C-;") 'macrursors-mark-map)
-  (define-key macrursors-mark-map (kbd "C-;") #'macrursors-mark-all-lines-or-instances)
-  (define-key macrursors-mark-map (kbd ";") #'macrursors-mark-all-lines-or-instances)
-  (define-key macrursors-mark-map (kbd "l") #'macrursors-mark-all-lists)
-  (define-key macrursors-mark-map (kbd "s") #'macrursors-mark-all-symbols)
-  (define-key macrursors-mark-map (kbd "e") #'macrursors-mark-all-sexps)
-  (define-key macrursors-mark-map (kbd "f") #'macrursors-mark-all-defuns)
-  (define-key macrursors-mark-map (kbd "n") #'macrursors-mark-all-numbers)
-  (define-key macrursors-mark-map (kbd ".") #'macrursors-mark-all-sentences)
-  (define-key macrursors-mark-map (kbd "r") #'macrursors-mark-all-lines))
+  (use-package macrursors
+    :config
+    (dolist (mode '(corfu-mode goggles-mode beacon-mode))
+      (add-hook 'macrursors-pre-finish-hook mode)
+      (add-hook 'macrursors-post-finish-hook mode))
+    (define-prefix-command 'macrursors-mark-map)
+    (global-set-key (kbd "M-SPC") #'macrursors-grab)
+    (global-set-key (kbd "C-c SPC") #'macrursors-swap-grab)
+    (global-set-key (kbd "C-c S-SPC") #'macrursors-sync-grab)
+    (global-set-key (kbd "C->") #'macrursors-mark-next-instance-of)
+    (global-set-key (kbd "C-<") #'macrursors-mark-previous-instance-of)
+    (global-set-key (kbd "C-;") 'macrursors-mark-map)
+    (define-key macrursors-mark-map (kbd "C-;") #'macrursors-mark-all-lines-or-instances)
+    (define-key macrursors-mark-map (kbd ";") #'macrursors-mark-all-lines-or-instances)
+    (define-key macrursors-mark-map (kbd "l") #'macrursors-mark-all-lists)
+    (define-key macrursors-mark-map (kbd "s") #'macrursors-mark-all-symbols)
+    (define-key macrursors-mark-map (kbd "e") #'macrursors-mark-all-sexps)
+    (define-key macrursors-mark-map (kbd "f") #'macrursors-mark-all-defuns)
+    (define-key macrursors-mark-map (kbd "n") #'macrursors-mark-all-numbers)
+    (define-key macrursors-mark-map (kbd ".") #'macrursors-mark-all-sentences)
+    (define-key macrursors-mark-map (kbd "r") #'macrursors-mark-all-lines))
 #+end_src
 
 * Documentation


### PR DESCRIPTION
**macrursors.el** (`macrursors-end`, `macrursors-preapply-command`, `macrursors-postapply-command`): Change the preapply/postapply-command variables to hooks, namely: 

- `macrursors-pre-finish-hook`: Hook run before applying macros.
- `macrursors-post-finish-hook`: Hook run after applying macros.

There are two reasons for this change:

1. It's more convenient to simply add functions to a hook with add-hook instead of modifying a lambda. This:

``` emacs-lisp
(add-hook 'macrursors-pre-finish-hook #'corfu-mode)
(add-hook 'macrursors-post-finish-hook #'corfu-mode)
```

will do the right thing, disabling the mode before and enabling it after.

To add multiple hooks, we can do

``` emacs-lisp
(dolist (mode '(corfu-mode goggles-mode beacon-mode))
      (add-hook 'macrursors-pre-finish-hook mode)
      (add-hook 'macrursors-post-finish-hook mode))
```

Of course, we can still add anonymous thunks:

``` emacs-lisp
(add-hook 'macrursors-pre-finish-hook
          (lambda ()
            ;; Do something
            ))
```


2. This adheres to the elisp convention of using `pre-*-hook` and `post-*-hook` to run custom code before and after actions. See for instance `pre-command-hook`, `post-command-hook`, `magit-pre-refresh-hook`, `magit-post-refresh-hook` etc.

**README.org (Usage, Speed)**: Update with hook description and usage.

## One hook vs two

It's actually simpler to just have a single hook that runs before and after the macro application, let's say `macrursors-execute-hook`.  Then this:

``` emacs-lisp
(add-hook 'macrursors-execute-hook 'corfu-mode)
```

will disable it before and enable it after.  However I didn't go this route, because having separate pre- and post- hooks is more flexible. For example, using the pre-hook we can save the keyboard macro we just defined for later:

``` emacs-lisp
(defvar macrursors-last-macro nil
  "Last macro applied by macrursors.")

(add-hook 'macrursors-pre-finish-hook
          (lambda ()
            (kmacro-name-last-macro
             'macrursors-last-macro)))
```

So the user can run `M-x macrursors-last-macro` at any time.

In the post-hook we can remove it from the kmacro ring so it doesn't interfere with macros explicitly defined by the user:

``` emacs-lisp
(add-hook 'macrursors-post-finish-hook
          (lambda () (kmacro-delete-ring-head)))
```

Not saying we should do this -- just that having separate pre- and post- hooks might be worth the trouble.