### PR TITLE
DWIM behavior, composable commands and more

### DIFF
--- a/macrursors.el
+++ b/macrursors.el
@@ -114,6 +114,8 @@ and re-enable them in `macrursors-post-finish-hook'."
         (point)
         (overlay-end mouse-secondary-overlay))))
 
+
+;;;; Macrursor overlay manipulation functions
 ;; TODO maybe add support for multiple types of cursor types
 (defun macrursors--add-overlay-at-point (pos)
   "Create an overlay to draw a fake cursor at POS."
@@ -144,6 +146,8 @@ If OVERLAYS in non-nil, return a list with the positions of OVERLAYS."
    #'overlay-start
    (or overlays macrursors--overlays)))
 
+
+;;;; Generic functions and commands for creating macrursors.
 (defun macrursors--instance-with-bounds (&optional regexp)
   "Return an appropriate string or object-type (symbol) for
 creating macrursors.
@@ -286,6 +290,8 @@ beginning and ending positions."
       (push-mark)
       (goto-char closest-ahead))))
 
+
+;;;; Commands to create macrursors from Isearch
 (defun macrursors--isearch-regexp ()
   (or isearch-success (user-error "Nothing to match."))
   (prog1
@@ -347,6 +353,8 @@ beginning and ending positions."
     (setq macrursors--instance regexp)
     (macrursors-start)))
 
+
+;;;; Commands to create macrursors at syntactic units ("things")
 ;;;###autoload
 (defmacro macrursors--defun-mark-all (name thing func)
   `(defun ,name ()
@@ -503,6 +511,8 @@ Else, mark all lines."
       (macrursors-mark-all-instances-of)
     (macrursors-mark-all-lines)))
 
+
+;;;; Functions that apply the defined macro across all macrursors
 (defun macrursors-start ()
   "Start kmacro recording, apply to all cursors when terminate."
   (interactive)


### PR DESCRIPTION
Following the discussion from #2, this PR does the following things:

1 `macrursors-mark-next-instance-of` and `macrursors-mark-previous-instance-of` now create cursors in this order:
  - If region is active, at the next/prev instance of the region contents
  - If there's a symbol at point, at the next/prev instance of the region contents
  - At the next/prev line

2. Add numeric prefix args to -mark-next and -mark-previous commands to mark multiple units at once.
3. A negative prefix arg will remove the latest arg cursors.
  
   Demo:
   
   https://user-images.githubusercontent.com/8607532/219531674-87fbda79-1347-41c4-85f7-63974227fbfb.mp4


4. New commands `macrursors-mark-next-from-isearch` and `macrursors-mark-previous-from-isearch` to mark the next and previous instance of the current isearch string (including regexps).  Numeric prefix and negative args are supported.  These can be chained with the other mark commands, like `macrusors-mark-next-instance-of`.

  Demo:
  
  https://user-images.githubusercontent.com/8607532/219531696-d6e133c4-b054-4c42-a033-2a19abfa351f.mp4

5. Composability pass: Every command can be followed by every other. For example,
  - `-mark-all-instances-of` can be followed by `-mark-next` with a negative prefix arg to remove cursors,
  - `-mark-next-from-isearch` can be followed by `-mark-previous` to match more previous instances, and so on.

  Demo:
  
  https://user-images.githubusercontent.com/8607532/219531725-59d37017-b444-4c72-aebd-8ef89604029c.mp4

6. New commands `macrursors-mark-next-line` and `macrursors-mark-previous-line`.  These are used by `macrursors-mark-next-instance-of` etc, but also useful to quickly create a bunch of cursors around point.  Faster than selecting a region, turning on the secondary selection and running `macrursors-mark-all-lines`.

  Demo:
  
  https://user-images.githubusercontent.com/8607532/219531770-e34c186c-631b-4814-9135-9da31601b1ee.mp4
  
  (Note: in this demo I'm using `repeat-mode` to avoid typing `C-; C-n` over and over.  See below.)


7. `repeat-mode` is **not** part of this PR.  However I'm mentioning it here because using a repeat-map is very handy for quick cursor creation.  In this demo I create cursors both at symbol locations and on lines (see command-log window on the right):

   https://user-images.githubusercontent.com/8607532/219531785-4b668868-0fa3-40ba-80a9-4c495127911e.mp4
   
   My repeat-mode setup is:
   
``` emacs-lisp
(defvar macrursors-repeat-map
  (let ((map (make-sparse-keymap)))
    (define-key map "n" #'macrursors-mark-next-instance-of)
    (define-key map "p" #'macrursors-mark-previous-instance-of)
    (define-key map (kbd "C-n") #'macrursors-mark-next-line)
    (define-key map (kbd "C-p") #'macrursors-mark-previous-line)
    map))
(map-keymap (lambda (_ cmd)
              (put cmd 'repeat-map 'macrursors-repeat-map))
            macrursors-repeat-map)
(dolist (cmd '(macrursors-mark-next-from-isearch
               macrursors-mark-previous-from-isearch))
  (put cmd 'repeat-map 'macrursors-repeat-map))
```

Note that there are edge cases that I haven't covered -- more testing is needed.  I'll fix them as they are reported.