### PR TITLE
Add `regexp-quote` search string for mark instance of functions

### DIFF
--- a/macrursors.el
+++ b/macrursors.el
@@ -185,7 +185,7 @@ beginning and ending positions."
             symb-beg symb-end)))))
 
 (defun macrursors--mark-all-instances-of (string orig-point &optional end)
-  (while (re-search-forward string end t)
+  (while (re-search-forward (regexp-quote string) end t)
     (unless (= (point) orig-point)
       (macrursors--add-overlay-at-point (point)))))
 
@@ -216,7 +216,7 @@ beginning and ending positions."
   (let ((cursor-positions (macrursors--get-overlay-positions))
         (matched-p))
     (while (and (setq matched-p
-                      (re-search-forward string end t 1))
+                      (re-search-forward (regexp-quote string) end t 1))
                 (member (point) cursor-positions)))
     (if (or (not matched-p)
             (> (point) (or end (point-max)))
@@ -251,7 +251,7 @@ beginning and ending positions."
   (let ((cursor-positions (macrursors--get-overlay-positions))
         (matched))
     (while (and (setq matched
-                      (re-search-forward string start t -1))
+                      (re-search-forward (regexp-quote string) start t -1))
                 (member (match-end 0) cursor-positions)))
     (if (or (not matched)
             (<= (point) (or start (point-min)))


### PR DESCRIPTION
Added step to `regexp-quote` the search string for the functions:
- `macrursors-mark-all-instances-of`
- `macrursors-mark-next-instance-of`
- `macrursors-mark-previous-instance-of`

This fixes an issue where special characters in the region would be interpreted as a regular expression during the marking process. Here is an example of this issue:

https://user-images.githubusercontent.com/29784485/220741581-4392cadf-d113-44ea-9051-934a4ee68448.mov

In the recording above, I am calling `macrursors-mark-next-instance-of`. Here is the updated way it works:

https://user-images.githubusercontent.com/29784485/220742563-8263d9fa-58a9-4eb8-8e5f-1bffcda5f41d.mov