### PR TITLE
Replace deprecated cl with cl-lib

### DIFF
--- a/macrursors-select.el
+++ b/macrursors-select.el
@@ -1,6 +1,6 @@
 (require 'macrursors)
 (require 'thingatpt)
-(require 'cl)
+(require 'cl-lib)
 (require 'select)
 
 (defun macrursors-select--set (beg end &optional type)


### PR DESCRIPTION
Hello! 

This fixes `package cl is deprecated` error when invoking `macrursors-select` command.